### PR TITLE
Add energy dashboard support

### DIFF
--- a/raven/parser.py
+++ b/raven/parser.py
@@ -3,8 +3,8 @@ import xml.etree.ElementTree as ET
 kEpochSeconds = 946684800  # Number of seconds between UNIX epoch (1970-01-01) and device epoch (2000-01-01)
 
 kValueMap = {
-    "InstantaneousDemand": "Demand",
-    "CurrentSummationDelivered": "SummationDelivered",
+    "InstantaneousDemand": ( "Demand", ),
+    "CurrentSummationDelivered": ( "SummationDelivered", "SummationReceived" ),
 }
 
 
@@ -16,8 +16,9 @@ class RavenMessage(dict):
     def __str__(self):
         return self.name + ": " + dict.__str__(self)
 
-    def value(self):
-        return self.calculate_number(kValueMap[self.name])
+    def values(self):
+        for number in kValueMap[self.name]:
+            yield (number, self.calculate_number(number))
 
     def calculate_number(self, tag):
         if tag in self and "Divisor" in self and "Multiplier" in self:


### PR DESCRIPTION
Home Automation added support for energy dashboard
(https://www.home-assistant.io/blog/2021/08/04/home-energy-management/)

To work, we need to report the amount of energy (in kWh) received and
sent to the grid.

Add code to handle SummationDelivered and SummationReceived.

The sensor on the home automation side will look like:
- name: "Home Netmeter Delivered"
  platform: mqtt
  state_topic: "Home/energy/delivered"
  state_class: total_increasing
  device_class: energy
  qos: 0
  unit_of_measurement: "kWh"
  value_template: '{{ value_json.val }}'

- name: "Home Netmeter Received"
  platform: mqtt
  state_topic: "Home/energy/received"
  state_class: total_increasing
  device_class: energy
  qos: 0
  unit_of_measurement: "kWh"
  value_template: '{{ value_json.val }}'